### PR TITLE
Fix capitalization in the readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,24 +1,24 @@
 # hyperterm-art
-This repository is dedicated to containing any and all art assets related to [Hyperterm](https://github.com/zeit/hyperterm).
+This repository is dedicated to containing any and all art assets related to [HyperTerm](https://github.com/zeit/hyperterm).
 
 ### Sketch File
-The sketch file included in this repository contains designed states of what appears in the Hyperterm application. It can help when submitting a feature request to download the sketch file and mockup the feature you'd like to see implemented.
+The Sketch file included in this repository contains designed states of what appears in the HyperTerm application. It can help when submitting a feature request to download the Sketch file and mockup the feature you'd like to see implemented.
 
-_Requires OSX/Mac OS, Apple System Font ([San Francisco](https://developer.apple.com/fonts/)) and [Hack](http://sourcefoundry.org/hack/)._
+_Requires macOS (OS X), Apple System Font ([San Francisco](https://developer.apple.com/fonts/)) and [Hack](http://sourcefoundry.org/hack/)._
 
 ### Logo
-The lightning symbol in the hyperterm brand mark is based on
+The lightning symbol in the HyperTerm brand mark is based on
 [this](http://www.flaticon.com/free-icon/lightning-symbol_74595) by [Freepik](http://www.freepik.com/).
 
-![Hyperterm Logo](/branding/Hyperterm-Mark-Large.png)
+![HyperTerm Logo](/branding/Hyperterm-Mark-Large.png)
 
 ### What should I do with the items in this repo?
-- Show the mark to link back to [Hyperterm](https://github.com/zeit/hyperterm).
-- Show the mark in articles/blog posts etc. whilst talking about Hyperterm.
+- Show the mark to link back to [HyperTerm](https://github.com/zeit/hyperterm).
+- Show the mark in articles/blog posts etc. whilst talking about HyperTerm.
 
 ### What shouldn't I do with the items in this repo?
 - Please don't use the mark as your own logo/icon or your application's logo/icon.
 - Modify and use the mark
 - Integrate the mark into your own logo
 
-_Inspiration for recommendations taken from [GitHubs Logo File](https://github.com/logos)._
+_Inspiration for recommendations taken from [GitHub's Logo File](https://github.com/logos)._


### PR DESCRIPTION
Mostly `Hyperterm` => `HyperTerm` and some other minor nitpick.